### PR TITLE
Benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,38 @@
+name: Run benchmarks
+
+on:
+  pull_request:
+
+jobs:
+  Benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1.4
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+      - name: Run benchmarks
+        run: julia -e '
+          using PkgBenchmark, BenchmarkCI;
+          BenchmarkCI.judge(
+              PkgBenchmark.BenchmarkConfig(
+                  env = Dict(
+                      "JULIA_NUM_THREADS" => "1",
+                      "OMP_NUM_THREADS" => "1",
+                  ),
+              );
+          );'
+      - name: Show
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'
+      - name: Push results
+        run: julia -e '
+          using BenchmarkCI;
+          BenchmarkCI.postjudge()
+          BenchmarkCI.pushresult(;
+              url = "git@github.com:Oblynx/HierarchicalTemporalMemory.jl",
+          );'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SSH_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    env:
+      JULIA_DEBUG: BenchmarkCI
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.4'
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+      - name: Run benchmarks
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
+      - name: Show
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'
+      - name: Post results
+        run: julia -e "using BenchmarkCI; BenchmarkCI.postjudge()"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,23 +57,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-  benchmark:
-    name: Benchmark
-    runs-on: ubuntu-latest
-    env:
-      JULIA_DEBUG: BenchmarkCI
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1.4'
-      - name: Install dependencies
-        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI"'
-      - name: Run benchmarks
-        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
-      - name: Show
-        run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'
-      - name: Post results
-        run: julia -e "using BenchmarkCI; BenchmarkCI.postjudge()"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           version: '1.4'
       - name: Install dependencies
-        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI"'
       - name: Run benchmarks
         run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
       - name: Show

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,41 @@
+using HierarchicalTemporalMemory, BenchmarkTools, CSV
+import Random.seed!
+seed!(0)
+
+include("setup.jl")
+
+SUITE = BenchmarkGroup()
+SUITE["SP"] = BenchmarkGroup()
+SUITE["TM"] = BenchmarkGroup()
+
+sp, refTM, data, encode, decoder= setupHTMexperiment()
+z,_= encode(data,1)
+
+let grp= SUITE["SP"]
+  # Run 1 iteration of SP adaptation repeatedly
+  grp["SP: 1 iteration"]= @benchmarkable step!(sp,z)
+end
+
+let grp= SUITE["TM"]
+  tN= size(data,1)
+  a= Vector{sp(z)|>typeof}(undef,tN)
+  for t= 1:tN
+    z,_= encode(data,t)
+    a[t]= step!(sp,z)
+  end
+  # The TM grows new dendrites/synapses at every step, and it will try to grow more
+  # if the input is random. So try giving it reasonable input sequences.
+  grp["TM: first 100 steps"]= @benchmarkable for t= 1:100
+      step!(tm,$a[t])
+    end setup=( tm= deepcopy($refTM) )
+
+  for t= 1 : tN-100
+    step!(refTM,a[t])
+  end
+  grp["TM: last 100 steps"]= @benchmarkable for t= $tN-99:$tN
+      step!(tm,$a[t])
+    end setup=( tm= deepcopy($refTM) )
+end
+
+#tune!(SUITE)
+#results= run(SUITE, verbose=true, seconds=20)

--- a/benchmark/setup.jl
+++ b/benchmark/setup.jl
@@ -37,7 +37,7 @@ function setupHTMexperiment(;
             p⁻_01=0.08,
             LTD_p⁻_01= 0.012
           ),
-      dataFilepath= "../test/test_data/gym_power_benchmark-extended.csv")
+      dataFilepath= "test/test_data/gym_power_benchmark-extended.csv")
   data= CSV.read(dataFilepath)
   encParams= initenc_powerDay(data.power_hourly_kw, data.hour, data.is_weekend,
                   encoder_size=inputDims[1], w=(34,35,35))

--- a/benchmark/setup.jl
+++ b/benchmark/setup.jl
@@ -1,0 +1,52 @@
+"""
+`setupHTMexperiment(; inputDims,spDims,k, spParams,tmParams, dataFilepath)` initializes an HTM system
+for a quick experiment with reasonable defaults.
+It assumes the power/day/wkend data encoding.
+
+# Returns
+
+- `SpatialPooler`
+- `TemporalMemory`
+- `data`
+- `z,bucket = encode(data,t)`
+- `decoder`
+"""
+function setupHTMexperiment(;
+      inputDims= ((15,6,3).*25,),
+      spDims= (1800,),
+      k= 8,
+      spParams= SPParams(
+            szᵢₙ= map(sum,inputDims), szₛₚ=spDims,
+            γ=1000,
+            s=0.03,
+            prob_synapse=0.85,
+            θ_stimulus_activate=5,
+            p⁺_01= 0.20,
+            p⁻_01= 0.12,
+            β=3,
+            Tboost=350,
+            enable_local_inhibit=false,
+            enable_boosting=true),
+      tmParams= TMParams(
+            Nc=prod(spDims),
+            k=k,
+            θ_stimulus_activate=14,
+            θ_stimulus_learn=12,
+            synapseSampleSize=35,
+            p⁺_01=0.24,
+            p⁻_01=0.08,
+            LTD_p⁻_01= 0.012
+          ),
+      dataFilepath= "../test/test_data/gym_power_benchmark-extended.csv")
+  data= CSV.read(dataFilepath)
+  encParams= initenc_powerDay(data.power_hourly_kw, data.hour, data.is_weekend,
+                  encoder_size=inputDims[1], w=(34,35,35))
+  decoder= SDRClassifier(tmParams.Nₙ,encParams.power_p.buckets,
+                    α=0.09, buffer_length=1)
+
+  encode= (data,t) -> encode_powerDay(data.power_hourly_kw[t], data.hour[t], data.is_weekend[t];
+                       encParams...)
+  (SpatialPooler(spParams),
+  TemporalMemory(tmParams),
+  data, encode, decoder)
+end


### PR DESCRIPTION
close #32 

Benchmarks don't seem to be standardized in other packages. ImageFiltering uses `PkgBenchmarks` & `BenchmarkCI` together, but it might be the case that `BenchmarkCI` is deprecated since I don't find it on github.

The CI needs to change to only use [`PkgBenchmark`](https://juliaci.github.io/PkgBenchmark.jl/stable/run_benchmarks/).