### PR TITLE
Add learn switch to step!

### DIFF
--- a/src/Region.jl
+++ b/src/Region.jl
@@ -64,7 +64,7 @@ RegionOutput= NamedTuple{(:active, :predictive, :bursting)}
 (r::Region)(proximal::RegionOutput, distal=falses(0))= r(proximal.active, distal)
 
 """
-    step!(r::Region, proximal, distal=falses(0), learn= true)
+    step!(r::Region, proximal, distal=falses(0); learn= true)
 
 Stimulates the region with the given inputs, adapting it following the learning rules.
 If distal input isn't given explicitly, recurrent connections are still used (if present).
@@ -72,7 +72,7 @@ If `learn == false`, the synapses are not adapted.
 
 See also [`Region`](@ref)
 """
-step!(r::Region, proximal, distal=falses(0), learn= true)= @chain gateCombine(proximal) begin
+step!(r::Region, proximal, distal=falses(0); learn= true)= @chain gateCombine(proximal) begin
   step!(r.sp, _, learn)
   step!(r.tm, _, gateCombine(distal), learn)
 end

--- a/src/Region.jl
+++ b/src/Region.jl
@@ -64,16 +64,17 @@ RegionOutput= NamedTuple{(:active, :predictive, :bursting)}
 (r::Region)(proximal::RegionOutput, distal=falses(0))= r(proximal.active, distal)
 
 """
-    step!(r::Region, proximal, distal=falses(0))
+    step!(r::Region, proximal, distal=falses(0), learn= true)
 
 Stimulates the region with the given inputs, adapting it following the learning rules.
 If distal input isn't given explicitly, recurrent connections are still used (if present).
+If `learn == false`, the synapses are not adapted.
 
 See also [`Region`](@ref)
 """
-step!(r::Region, proximal, distal=falses(0))= @chain gateCombine(proximal) begin
-  step!(r.sp, _)
-  step!(r.tm, _, gateCombine(distal))
+step!(r::Region, proximal, distal=falses(0), learn= true)= @chain gateCombine(proximal) begin
+  step!(r.sp, _, learn)
+  step!(r.tm, _, gateCombine(distal), learn)
 end
 
 "`reset!(r::Region)` unlearns the region's synapses (and other internal state), restoring it to the state at construction"

--- a/src/SpatialPooler.jl
+++ b/src/SpatialPooler.jl
@@ -192,15 +192,17 @@ end
 # SP adaptation
 
 """
-`step!(sp::SpatialPooler, z::CellActivity)` evolves the Spatial Pooler to the next timestep
-by evolving each of its constituents (synapses, boosting, inhibition radius)
-and returns the output activation.
+    step!(sp::SpatialPooler, z::CellActivity, learn= true)
+
+Evolves the Spatial Pooler to the next timestep by evolving each of its constituents
+(synapses, boosting, inhibition radius) and returns the output activation.
+If `learn == false`, the synapses are not adapted.
 
 See also: [`sp_activate`](@ref)
 """
-function step!(sp::SpatialPooler, z)
+function step!(sp::SpatialPooler, z, learn= true)
   a= sp_activate(sp, z)
-  if sp.params.enable_learning
+  if learn && sp.params.enable_learning
     step!(sp.synapses, z,a, sp.params)
     step_boost!(sp,a)
     # φ kept static for the moment (no obvious benefit from dynamic φ)

--- a/src/TemporalMemory.jl
+++ b/src/TemporalMemory.jl
@@ -126,14 +126,16 @@ reset!(tm::TemporalMemory)= begin
 end
 
 """
-`step!(tm::TemporalMemory, c, distal_input=[])` evolves the Temporal Memory to the next timestep
-given the minicolumn activations and any distal input.
+    step!(tm::TemporalMemory, c, distal_input=[], learn= true)
+
+Evolves the Temporal Memory to the next timestep, given the minicolumn activations and any distal input.
 Returns the state of the region's neurons: active, predictive, bursting (minicolumns)
+If `learn == false`, the synapses are not adapted.
 
 See also: [`tm_activate`](@ref), [`tm_predict`](@ref)
 """
 # Given a column activation pattern `c` (SP output), step the TM
-function step!(tm::TemporalMemory, c, distal_input=falses(0))
+function step!(tm::TemporalMemory, c, distal_input=falses(0), learn= true)
   s= tm.distalSynapses; p= tm.previous
 
   α, B, WN= tm_activate(tm, c, p.Π)
@@ -145,7 +147,7 @@ function step!(tm::TemporalMemory, c, distal_input=falses(0))
   WS, WS_burst= calculate_WS!(s, p.Πₛ,p.ovp_Mₛ,α,B)
   # Update winner neurons with entries from bursting columns
   WN[NS(s)*WS_burst .> 0].= true
-  step!(s, p.WN,WS, α, p.α,p.Mₛ,p.ovp_Mₛ)
+  learn && step!(s, p.WN,WS, α, p.α,p.Mₛ,p.ovp_Mₛ)
   update_TMState!(p, Nseg=Nₛ(s),
                   α=α, Π=Π, WN=WN, Πₛ=Πₛ, Mₛ=Mₛ, ovp_Mₛ=ovp_Mₛ)
   return (


### PR DESCRIPTION
There is a valid use case of stimulating the temporal memory without adapting its synapses. This allows modifying its predictive/winning neurons, which will change the next output.

Example:

```julia
A= Region(SPParams(), TMParams())
x= bitrand(500)
x2= bitrand(500)  # another input

# Unexpected input, no predictive neurons, massive bursting
unexpected_x= A(x)

[step!(A,x) for t=1:10]
# Expected input. Due to previous stimulation, learned recurrent synapses are likely to predict
# the next stimulus, resulting in much less excitation
expected_x= A(x)

# therefore, this will be true:
count(expected_x) < count(unexpected_x)

# an unexpected input will break the series
step!(A,x2)
# and stimulating again with x will be unexpected, causing bursting
unexpected_x_afterlearn= A(x)

# however, the connections that allow to expect x are still there
# and therefore, stimulating with x once again should produce a very similar output as before
step!(A,x)
expected_x_2= A(x)
expected_x_2 ≈ expected_x  # approximately same

# step!(learn= false)
# this will allow us to receive an output very similar to `expected_x_2`, but without adapting the synapses further:
step!(A,x, learn=false)
expected_x_3= A(x)
expected_x_3 ≈ expected_x_2  # approximately same
```

The advantage of `step!(A,x, learn=false)` is that, since the synapses aren't adapted, it allows less "disruptive" probing of the learned sequence by only changing the set of predictive neurons.